### PR TITLE
Fix openapi external basepath

### DIFF
--- a/openapi/external.yaml
+++ b/openapi/external.yaml
@@ -8,7 +8,7 @@ info:
     Documentation of the IO Lollipop Function API exposed to Lollipop
     Consumerhere.
 servers:
-  - url: https://api.pagopa.it/api/v1/lollipop
+  - url: https://api.pagopa.it/lollipop/api/v1
 security:
   - ApiKeyAuth: []
 paths:

--- a/openapi/external.yaml.template
+++ b/openapi/external.yaml.template
@@ -1,17 +1,17 @@
 openapi: 3.0.1
 info:
-  version: 0.0.0 
+  version: 0.0.0
   title: IO Lollipop Function Lollipop Consumer API
   x-logo:
     url: https://io.italia.it/assets/img/io-logo-blue.svg
   description: |
     Documentation of the IO Lollipop Function API exposed to Lollipop Consumerhere.
 servers: 
-  - url: https://api.pagopa.it/api/v1/lollipop
+  - url: https://api.pagopa.it/lollipop/api/v1
 security:
   - ApiKeyAuth: []
 paths:
-  /assertions/{assertion_ref}:     
+  /assertions/{assertion_ref}:
     get:
       operationId: getAssertion
       summary: Get Assertion related to a given assertion ref
@@ -52,7 +52,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProblemJson"            
+                $ref: "#/components/schemas/ProblemJson"
 
 components:
   securitySchemes:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Change the server url value to `https://api.pagopa.it/lollipop/api/v1`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The url param in external openapi is wrong. The client generated from this spec will have a wrong base path.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
not tested

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
