### PR TITLE
[#IOPID-106] add `assertionRef` to exception, enable sampling

### DIFF
--- a/HandlePubKeyRevoke/__tests__/handler.test.ts
+++ b/HandlePubKeyRevoke/__tests__/handler.test.ts
@@ -96,8 +96,10 @@ describe("handleRevoke", () => {
     expect(mockAppinsights.trackException).toHaveBeenCalled();
     expect(mockAppinsights.trackException).toHaveBeenCalledWith(
       expect.objectContaining({
+        tagOverrides: { samplingEnabled: "false" },
         properties: expect.objectContaining({
           detail: "PERMANENT",
+          assertionRef: "unknown",
           name: "lollipop.pubKeys.revoke.failure",
           retryCount: "1",
           maxRetryCount: "5"
@@ -128,13 +130,56 @@ describe("handleRevoke", () => {
     expect(mockAppinsights.trackException).toHaveBeenCalled();
     expect(mockAppinsights.trackException).toHaveBeenCalledWith(
       expect.objectContaining({
+        tagOverrides: { samplingEnabled: "true" },
         properties: expect.objectContaining({
           detail: "TRANSIENT",
           fatal: "false",
           isSuccess: "false",
           modelId: "",
+          assertionRef: aValidAssertionRef,
           name: "lollipop.pubKeys.revoke.failure",
           retryCount: "1",
+          maxRetryCount: "5"
+        })
+      })
+    );
+    expect(findLastVersionByModelIdMock).toHaveBeenCalledTimes(1);
+    expect(findLastVersionByModelIdMock).toHaveBeenCalledWith([
+      aValidRevokeInput.assertion_ref
+    ]);
+  });
+
+  it("GIVEN a valid revoke message WHEN findLastVersion fails the last retry THEN it should throw with a transient failure without sampling", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      TE.left(toCosmosErrorResponse("Cannot reach cosmosDB"))
+    );
+    await expect(
+      handleRevoke(
+        {
+          ...contextMock,
+          executionContext: {
+            retryContext: { retryCount: 4, maxRetryCount: 5 }
+          }
+        },
+        mockAppinsights as any,
+        lollipopKeysModelMock,
+        masterAlgo,
+        aValidRevokeInput
+      )
+    ).rejects.toBeDefined();
+
+    expect(mockAppinsights.trackException).toHaveBeenCalled();
+    expect(mockAppinsights.trackException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tagOverrides: { samplingEnabled: "false" },
+        properties: expect.objectContaining({
+          detail: "TRANSIENT",
+          fatal: "false",
+          isSuccess: "false",
+          modelId: "",
+          assertionRef: aValidAssertionRef,
+          name: "lollipop.pubKeys.revoke.failure",
+          retryCount: "4",
           maxRetryCount: "5"
         })
       })
@@ -243,8 +288,10 @@ describe("handleRevoke", () => {
     expect(mockAppinsights.trackException).toHaveBeenCalled();
     expect(mockAppinsights.trackException).toHaveBeenCalledWith(
       expect.objectContaining({
+        tagOverrides: { samplingEnabled: "false" },
         properties: expect.objectContaining({
           detail: "PERMANENT",
+          assertionRef: aValidAssertionRef,
           name: "lollipop.pubKeys.revoke.failure",
           retryCount: "1",
           maxRetryCount: "5"
@@ -285,8 +332,10 @@ describe("handleRevoke", () => {
     expect(mockAppinsights.trackException).toHaveBeenCalled();
     expect(mockAppinsights.trackException).toHaveBeenCalledWith(
       expect.objectContaining({
+        tagOverrides: { samplingEnabled: "false" },
         properties: expect.objectContaining({
           detail: "PERMANENT",
+          assertionRef: aValidAssertionRef,
           name: "lollipop.pubKeys.revoke.failure",
           retryCount: "1",
           maxRetryCount: "5"
@@ -331,8 +380,10 @@ describe("handleRevoke", () => {
     expect(mockAppinsights.trackException).toHaveBeenCalled();
     expect(mockAppinsights.trackException).toHaveBeenCalledWith(
       expect.objectContaining({
+        tagOverrides: { samplingEnabled: "true" },
         properties: expect.objectContaining({
           detail: "TRANSIENT",
+          assertionRef: aValidAssertionRef,
           name: "lollipop.pubKeys.revoke.failure",
           retryCount: "1",
           maxRetryCount: "5"
@@ -371,10 +422,12 @@ describe("handleRevoke", () => {
     expect(mockAppinsights.trackException).toHaveBeenCalled();
     expect(mockAppinsights.trackException).toHaveBeenCalledWith(
       expect.objectContaining({
+        tagOverrides: { samplingEnabled: "true" },
         properties: expect.objectContaining({
           detail: "TRANSIENT",
           name: "lollipop.pubKeys.revoke.failure",
           retryCount: "1",
+          assertionRef: aValidAssertionRef,
           maxRetryCount: "5",
           errorMessage: expect.stringContaining(
             "Cannot find a master lollipopPubKey"
@@ -414,8 +467,10 @@ describe("handleRevoke", () => {
     expect(mockAppinsights.trackException).toHaveBeenCalled();
     expect(mockAppinsights.trackException).toHaveBeenCalledWith(
       expect.objectContaining({
+        tagOverrides: { samplingEnabled: "true" },
         properties: expect.objectContaining({
           detail: "TRANSIENT",
+          assertionRef: aValidAssertionRef,
           errorMessage: expect.stringContaining(
             "Cannot decode a VALID master lollipopPubKey"
           ),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

- Add `assertionRef` to exception properties
- Enable sampling
- Update tests

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Enable the ability to retrieve assertionRef when all retries have failed.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
