### PR TITLE
[#IOPID-433] The Keyid in signature-params has a thumbprint

### DIFF
--- a/FirstLollipopConsumerSignedMessage/__tests__/handler.test.ts
+++ b/FirstLollipopConsumerSignedMessage/__tests__/handler.test.ts
@@ -11,8 +11,12 @@ import { aSAMLResponse } from "../../__mocks__/assertion.mock";
 import {
   aValidPayload,
   firstLcAssertionClientConfig,
-  validLollipopHeaders
+  validLollipopExtraHeaders
 } from "../../__mocks__/lollipopSignature.mock";
+import { LollipopOriginalURL } from "../../generated/definitions/lollipop-first-consumer/LollipopOriginalURL";
+import { LollipopSignature } from "../../generated/definitions/lollipop-first-consumer/LollipopSignature";
+import { LollipopSignatureInput } from "../../generated/definitions/lollipop-first-consumer/LollipopSignatureInput";
+import { AssertionRef } from "../../generated/definitions/internal/AssertionRef";
 
 // -----------------
 // mocks
@@ -41,7 +45,23 @@ describe("FirstLollipopConsumerSignedMessage", () => {
       firstLcAssertionClientConfig
     );
 
-    const res = await handler(aValidJwk, validLollipopHeaders, aValidPayload);
+    const res = await handler(
+      aValidJwk,
+      {
+        ...validLollipopExtraHeaders,
+        "x-pagopa-lollipop-assertion-ref": "sha256-a7qE0Y0DyqeOFFREIQSLKfu5WlbckdxVXKFasfcI-Dg" as AssertionRef,
+        // ---------
+        // verified header
+        // ---------
+        ["x-pagopa-lollipop-original-method"]:
+          firstLcAssertionClientConfig.EXPECTED_FIRST_LC_ORIGINAL_METHOD,
+        ["x-pagopa-lollipop-original-url"]: firstLcAssertionClientConfig
+          .EXPECTED_FIRST_LC_ORIGINAL_URL.href as LollipopOriginalURL,
+        ["signature-input"]: `sig1=("content-digest" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1678293988;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="a7qE0Y0DyqeOFFREIQSLKfu5WlbckdxVXKFasfcI-Dg"` as LollipopSignatureInput,
+        ["signature"]: "sig1=:lTuoRytp53GuUMOB4Rz1z97Y96gfSeEOm/xVpO39d3HR6lLAy4KYiGq+1hZ7nmRFBt2bASWEpen7ov5O4wU3kQ==:" as LollipopSignature
+      },
+      aValidPayload
+    );
 
     expect(res).toMatchObject({
       kind: "IResponseSuccessJson",

--- a/FirstLollipopConsumerSignedMessage/__tests__/handler.test.ts
+++ b/FirstLollipopConsumerSignedMessage/__tests__/handler.test.ts
@@ -11,7 +11,7 @@ import { aSAMLResponse } from "../../__mocks__/assertion.mock";
 import {
   aValidPayload,
   firstLcAssertionClientConfig,
-  validLollipopExtraHeaders
+  validLollipopLCParamsHeaders
 } from "../../__mocks__/lollipopSignature.mock";
 import { LollipopOriginalURL } from "../../generated/definitions/lollipop-first-consumer/LollipopOriginalURL";
 import { LollipopSignature } from "../../generated/definitions/lollipop-first-consumer/LollipopSignature";
@@ -48,8 +48,7 @@ describe("FirstLollipopConsumerSignedMessage", () => {
     const res = await handler(
       aValidJwk,
       {
-        ...validLollipopExtraHeaders,
-        "x-pagopa-lollipop-assertion-ref": "sha256-a7qE0Y0DyqeOFFREIQSLKfu5WlbckdxVXKFasfcI-Dg" as AssertionRef,
+        ...validLollipopLCParamsHeaders,
         // ---------
         // verified header
         // ---------

--- a/__mocks__/lollipopSignature.mock.ts
+++ b/__mocks__/lollipopSignature.mock.ts
@@ -58,7 +58,7 @@ export const validLollipopHeaders = {
     firstLcAssertionClientConfig.EXPECTED_FIRST_LC_ORIGINAL_METHOD,
   ["x-pagopa-lollipop-original-url"]: firstLcAssertionClientConfig
     .EXPECTED_FIRST_LC_ORIGINAL_URL.href as LollipopOriginalURL,
-  ["signature-input"]: `sig1=("content-digest" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1678293988;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="sha256-a7qE0Y0DyqeOFFREIQSLKfu5WlbckdxVXKFasfcI-Dg"` as LollipopSignatureInput,
+  ["signature-input"]: `sig1=("content-digest" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1678293988;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="a7qE0Y0DyqeOFFREIQSLKfu5WlbckdxVXKFasfcI-Dg"` as LollipopSignatureInput,
   ["signature"]: "sig1=:lTuoRytp53GuUMOB4Rz1z97Y96gfSeEOm/xVpO39d3HR6lLAy4KYiGq+1hZ7nmRFBt2bASWEpen7ov5O4wU3kQ==:" as LollipopSignature,
   ["content-digest"]: "sha-256=:cpyRqJ1VhoVC+MSs9fq4/4wXs4c46EyEFriskys43Zw=:" as LollipopContentDigest
 };
@@ -66,6 +66,6 @@ export const validLollipopHeaders = {
 export const validMultisignatureHeaders = {
   ...validLollipopHeaders,
   "X-io-sign-qtspclauses": "anIoSignClauses",
-  ["signature-input"]: `sig1=("x-io-sign-qtspclauses");created=1678299228;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="sha256-a7qE0Y0DyqeOFFREIQSLKfu5WlbckdxVXKFasfcI-Dg", sig2=("content-digest" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1678299228;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="sha256-a7qE0Y0DyqeOFFREIQSLKfu5WlbckdxVXKFasfcI-Dg"` as LollipopSignatureInput,
+  ["signature-input"]: `sig1=("x-io-sign-qtspclauses");created=1678299228;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="a7qE0Y0DyqeOFFREIQSLKfu5WlbckdxVXKFasfcI-Dg", sig2=("content-digest" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1678299228;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="a7qE0Y0DyqeOFFREIQSLKfu5WlbckdxVXKFasfcI-Dg"` as LollipopSignatureInput,
   ["signature"]: "sig1=:dncsEeKERA9wzxBO0vbPIueMK7Izk4zZNX4D0jI+t17XQJ5YrhumR3MGvMiyarb+B8MPqn+rbOJwZt6dV+oXFA==:, sig2=:nbmFduqX8AdhXzqkFX+UIvicn3ZV5yZXqUO+3bceOT8WFPXRTVRcoOcjF+0+W5KLihAZjSW5GXSgCxVVEW8pqQ==:" as LollipopSignature
 };

--- a/__mocks__/lollipopSignature.mock.ts
+++ b/__mocks__/lollipopSignature.mock.ts
@@ -1,32 +1,89 @@
+import * as crypto from "crypto";
+import * as express from "express";
+import * as jose from "jose";
+
 import { pipe } from "fp-ts/lib/function";
 import * as E from "fp-ts/Either";
 
-import { JwkPublicKey } from "@pagopa/ts-commons/lib/jwk";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { UrlFromString, ValidUrl } from "@pagopa/ts-commons/lib/url";
 
 import { LollipopMethodEnum } from "../generated/definitions/lollipop-first-consumer/LollipopMethod";
 
 import { AssertionTypeEnum } from "../generated/definitions/internal/AssertionType";
-import { LollipopOriginalURL } from "../generated/definitions/lollipop-first-consumer/LollipopOriginalURL";
-import { LollipopSignature } from "../generated/definitions/lollipop-first-consumer/LollipopSignature";
-import { LollipopContentDigest } from "../generated/definitions/lollipop-first-consumer/LollipopContentDigest";
-import { LollipopSignatureInput } from "../generated/definitions/lollipop-first-consumer/LollipopSignatureInput";
 
 import { FirstLcAssertionClientConfig } from "../utils/config";
 
 import {
   aFiscalCode,
+  aValidJwk,
   aValidSha256AssertionRef,
   toEncodedJwk
 } from "./lollipopPubKey.mock";
+import {
+  CreateSignatureHeaderOptions,
+  createSignatureHeader
+} from "@mattrglobal/http-signatures";
 
-const aValidPublicKey: JwkPublicKey = {
-  kty: "EC",
-  x: "FqFDuwEgu4MUXERPMVL-85pGv2D3YmL4J1gfMkdbc24",
-  y: "hdV0oxmWFSxMoJUDpdihr76rS8VRBEqMFebYyAfK9-k",
-  crv: "P-256"
+// -------------------------------------
+// Private / Public ES256 Key Generation
+// -------------------------------------
+
+export const generateES256Key = async () => {
+  const key = await jose.generateKeyPair("ES256");
+  const pubKeyJwk = await jose.exportJWK(key.publicKey);
+  const privateKeyJwk = await jose.exportJWK(key.privateKey);
+
+  const encodedPubKey = toEncodedJwk(pubKeyJwk as any);
+  const thumbprintSha256 = `${await jose.calculateJwkThumbprint(
+    pubKeyJwk,
+    "sha256"
+  )}`;
+  const assertionRefSha256 = `sha256-${thumbprintSha256}`;
+
+  return {
+    encodedPubKey,
+    privateKeyJwk,
+    assertionRefSha256,
+    thumbprintSha256
+  };
 };
+
+// --------------------------------------
+// Private / Public RSA Key Generation
+// --------------------------------------
+
+export const generateRSAKey = async () => {
+  const key = await jose.generateKeyPair("RS256", {
+    modulusLength: 2048
+  });
+  const pubKeyJwk = {
+    ...(await jose.exportJWK(key.publicKey)),
+    alg: "sha256"
+  };
+  const privateKeyJwk = {
+    ...(await jose.exportJWK(key.privateKey)),
+    alg: "sha256"
+  };
+
+  const encodedPubKey = toEncodedJwk(pubKeyJwk as any);
+  const thumbprintSha256 = `${await jose.calculateJwkThumbprint(
+    pubKeyJwk,
+    "sha256"
+  )}`;
+  const assertionRefSha256 = `sha256-${thumbprintSha256}`;
+
+  return {
+    encodedPubKey,
+    privateKeyJwk,
+    assertionRefSha256,
+    thumbprintSha256
+  };
+};
+
+// --------------------------------------
+// end Private / Public Key
+// --------------------------------------
 
 export const aValidPayload = {
   message: "a valid message payload" as NonEmptyString
@@ -45,27 +102,171 @@ export const firstLcAssertionClientConfig: FirstLcAssertionClientConfig = {
   IDP_KEYS_BASE_URL: ("https://api.is.eng.pagopa.it/idp-keys" as unknown) as ValidUrl
 };
 
-export const validLollipopHeaders = {
+export const validLollipopExtraHeaders = {
   ["x-pagopa-lollipop-assertion-ref"]: aValidSha256AssertionRef,
   ["x-pagopa-lollipop-assertion-type"]: AssertionTypeEnum.SAML,
   ["x-pagopa-lollipop-user-id"]: aFiscalCode,
-  ["x-pagopa-lollipop-public-key"]: toEncodedJwk(aValidPublicKey),
-  ["x-pagopa-lollipop-auth-jwt"]: "aValidJWT" as NonEmptyString,
-  // ---------
-  // verified header
-  // ---------
-  ["x-pagopa-lollipop-original-method"]:
-    firstLcAssertionClientConfig.EXPECTED_FIRST_LC_ORIGINAL_METHOD,
-  ["x-pagopa-lollipop-original-url"]: firstLcAssertionClientConfig
-    .EXPECTED_FIRST_LC_ORIGINAL_URL.href as LollipopOriginalURL,
-  ["signature-input"]: `sig1=("content-digest" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1678293988;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="a7qE0Y0DyqeOFFREIQSLKfu5WlbckdxVXKFasfcI-Dg"` as LollipopSignatureInput,
-  ["signature"]: "sig1=:lTuoRytp53GuUMOB4Rz1z97Y96gfSeEOm/xVpO39d3HR6lLAy4KYiGq+1hZ7nmRFBt2bASWEpen7ov5O4wU3kQ==:" as LollipopSignature,
-  ["content-digest"]: "sha-256=:cpyRqJ1VhoVC+MSs9fq4/4wXs4c46EyEFriskys43Zw=:" as LollipopContentDigest
+  ["x-pagopa-lollipop-public-key"]: toEncodedJwk(aValidJwk),
+  ["x-pagopa-lollipop-auth-jwt"]: "aValidJWT" as NonEmptyString
 };
 
-export const validMultisignatureHeaders = {
-  ...validLollipopHeaders,
-  "X-io-sign-qtspclauses": "anIoSignClauses",
-  ["signature-input"]: `sig1=("x-io-sign-qtspclauses");created=1678299228;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="a7qE0Y0DyqeOFFREIQSLKfu5WlbckdxVXKFasfcI-Dg", sig2=("content-digest" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1678299228;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="a7qE0Y0DyqeOFFREIQSLKfu5WlbckdxVXKFasfcI-Dg"` as LollipopSignatureInput,
-  ["signature"]: "sig1=:dncsEeKERA9wzxBO0vbPIueMK7Izk4zZNX4D0jI+t17XQJ5YrhumR3MGvMiyarb+B8MPqn+rbOJwZt6dV+oXFA==:, sig2=:nbmFduqX8AdhXzqkFX+UIvicn3ZV5yZXqUO+3bceOT8WFPXRTVRcoOcjF+0+W5KLihAZjSW5GXSgCxVVEW8pqQ==:" as LollipopSignature
+// --------------------------------------------
+// Signature methods
+// --------------------------------------------
+
+export const signEcdsaSha256WithEncoding = (
+  dsaEncoding: "der" | "ieee-p1363"
+) => (key: crypto.JsonWebKey) => async (
+  data: Uint8Array
+): Promise<Uint8Array> => {
+  const keyObject = crypto.createPrivateKey({ key, format: "jwk" });
+  return crypto
+    .createSign("SHA256")
+    .update(data)
+    .sign({ key: keyObject, dsaEncoding });
+};
+
+export const signRsaPssSha256WithEncoding = (
+  dsaEncoding: "der" | "ieee-p1363"
+) => (key: crypto.JsonWebKey) => async (
+  data: Uint8Array
+): Promise<Uint8Array> => {
+  const keyObject = crypto.createPrivateKey({ key, format: "jwk" });
+  return await crypto
+    .createSign("SHA256")
+    .update(data)
+    .sign({
+      key: keyObject,
+      dsaEncoding,
+      padding: crypto.constants.RSA_PKCS1_PSS_PADDING
+    });
+};
+
+type SignFunction = (data: Uint8Array) => Promise<Uint8Array>;
+
+/**
+ * Create a signed LolliPoP request
+ */
+export const withLollipopSignature = (
+  keyid: string,
+  nonce: string,
+  alg: string,
+  privateKey: jose.JWK,
+  sign: (privateKey: jose.JWK) => SignFunction
+) => async (request: express.Request): Promise<express.Request> => {
+  const signWithPrivateKey = sign(privateKey);
+
+  const method = request?.method ?? "GET";
+  const url = request.url;
+
+  const lollipopHttpHeaders = {
+    ["x-pagopa-lollipop-original-method"]: method,
+    ["x-pagopa-lollipop-original-url"]: url
+  };
+
+  const prevHeaders = request?.headers
+    ? Object.keys(request.headers).reduce(
+        (p, c) => ({
+          ...p,
+          [c]: (request.headers as Record<string, string>)[c]
+        }),
+        {}
+      )
+    : {};
+
+  const bodyCovered: string[] = request?.body ? ["content-digest"] : [];
+
+  const options: CreateSignatureHeaderOptions = {
+    alg: alg as any,
+    nonce,
+    signer: { keyid, sign: signWithPrivateKey },
+    url,
+    method,
+    httpHeaders: { ...prevHeaders, ...lollipopHttpHeaders },
+    body: request?.body ? (request?.body as string) : undefined,
+    coveredFields: [
+      ...bodyCovered,
+      "x-pagopa-lollipop-original-method",
+      "x-pagopa-lollipop-original-url"
+    ].map(v => [v.toLowerCase(), new Map()])
+  };
+
+  const result = await createSignatureHeader(options);
+
+  if (result.isErr()) {
+    throw Error(result.error.message);
+  }
+
+  const h = result.value;
+
+  return ({
+    ...request,
+    headers: {
+      ...prevHeaders,
+      ...lollipopHttpHeaders,
+      ...(h.digest ? { ["content-digest"]: h.digest } : {}),
+      ["Signature"]: h.signature,
+      ["Signature-Input"]: h.signatureInput
+    }
+  } as any) as express.Request;
+};
+
+/**
+ * Create a signed request for io-sign header
+ */
+export const withIoSignLollipopSignature = (
+  keyid: string,
+  nonce: string,
+  alg: string,
+  privateKey: jose.JWK,
+  sign: (privateKey: jose.JWK) => SignFunction
+) => async (request: express.Request): Promise<express.Request> => {
+  if (!(request?.headers && "X-io-sign-qtspclauses" in request?.headers))
+    throw new Error("Missing X-io-sign-qtspclauses in headers");
+
+  const signWithPrivateKey = sign(privateKey);
+
+  const method = request?.method ?? "GET";
+  const url = request.url;
+
+  const prevHeaders = request?.headers
+    ? Object.keys(request.headers).reduce(
+        (p, c) => ({
+          ...p,
+          [c]: (request.headers as Record<string, string>)[c]
+        }),
+        {}
+      )
+    : {};
+
+  const options: CreateSignatureHeaderOptions = {
+    alg: alg as any,
+    nonce,
+    signer: { keyid, sign: signWithPrivateKey },
+    url,
+    method,
+    httpHeaders: prevHeaders,
+    body: request?.body ? (request?.body as string) : undefined,
+    coveredFields: ["X-io-sign-qtspclauses"].map(v => [
+      v.toLowerCase(),
+      new Map()
+    ])
+  };
+
+  const result = await createSignatureHeader(options);
+
+  if (result.isErr()) {
+    throw Error(result.error.message);
+  }
+
+  const h = result.value;
+
+  return ({
+    ...request,
+    headers: {
+      ...prevHeaders,
+      ["Signature"]: h.signature,
+      ["Signature-Input"]: h.signatureInput
+    }
+  } as any) as express.Request;
 };

--- a/utils/middleware/__tests__/http_message_signature_middleware.test.ts
+++ b/utils/middleware/__tests__/http_message_signature_middleware.test.ts
@@ -59,7 +59,7 @@ describe("HttpMessageSignatureMiddleware - Success", () => {
         Signature:
           "sig1=:LaN4n+miIZDzPHSV1CwFM/M+qzp0InLYlfxKfOC8b+VMv4q9leZSQcGwLC7uLpvdn4o8q9+LKc6zPbsD6NWtJclbwVLBXJKmpI7OzPkHJhho809JPHiFeQ49o/YfLXGKSlGp0kYmpP6KwsFivkuH54+/I5s5PDJacpQ5J2/j6MeFZH2arft9Kg5ZSOBZdG4EpvAxOrmje8bzIbaptb2DSxdX9YfNiYf6fuMjDnGOVAa3nz8z135tyvPj5tP8P2MKRDKVc2L1sUfpTIJ9HSjcEx6cxhBXdPwozdtVy/we7QXBl+c9fHzCytk3aNlaPh1B10MCwuKQiky8M1GCR1BMC5pIkhXenOcvj7hNkTe1FEwkvLWHCYdJzNLD8ERbTfsKEM1CZt7I5fMBr0/mitOJZ2GBIOnhZZya0oFnR5br22zvXoJL8lS1ajp3Wt3EXSdliDloy5LDOPqxAEH5nXInfxDaYQgZuLWa0I2oLmSr/DlW/KqX0KVCtoJXdwxJjhBS/ZRTdC0u2WmcE0QA0YXeJfUWaU8KS1Nx+Lbz22xEu7kNGTh7r8cmtVzl5bybtpvMUZ7dqNgoW5mcaCUDjeQOinRsugVWVTowTPjJWXW+8cV9LeBJRq4oc9HzoLQDfn/HGoMFpi79pZQIzNFBE3Jpdoouu392AqmEebzEgm2838A=:",
         ["Signature-Input"]:
-          'sig1=("content-digest" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1678814391;nonce="aNonce";alg="rsa-pss-sha256";keyid="sha256-A3OhKGLYwSvdJ2txHi_SGQ3G-sHLh2Ibu91ErqFx_58"'
+          'sig1=("content-digest" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1678814391;nonce="aNonce";alg="rsa-pss-sha256";keyid="A3OhKGLYwSvdJ2txHi_SGQ3G-sHLh2Ibu91ErqFx_58"'
       },
       url:
         "https://io-p-weu-lollipop-fn.azurewebsites.net/api/v1/first-lollipop-consumer",
@@ -119,7 +119,7 @@ describe("HttpMessageSignatureMiddleware - Success", () => {
           "https://api-app.io.pagopa.it/first-lollipop/sign",
         "content-digest":
           "sha-256=:cpyRqJ1VhoVC+MSs9fq4/4wXs4c46EyEFriskys43Zw=:",
-        "signature-input": `sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1681473980;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="sha256-HiNolL87UYKQfaKISwIzyWY4swKPUzpaOWJCxaHy89M"`,
+        "signature-input": `sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1681473980;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="HiNolL87UYKQfaKISwIzyWY4swKPUzpaOWJCxaHy89M"`,
         signature: `sig1=:MEUCIFiZHxuLhk2Jlt46E5kbB8hCx7fN7QeeAj2gaSK3Y+WzAiEAtggj3Jwu8RbTGdNmsDix2zymh0gKwKxoPlolL7j6VTg=:`
       },
       url: "https://api-app.io.pagopa.it/first-lollipop/sign",

--- a/utils/middleware/__tests__/http_message_signature_middleware.test.ts
+++ b/utils/middleware/__tests__/http_message_signature_middleware.test.ts
@@ -5,36 +5,60 @@ import * as E from "fp-ts/Either";
 import { HttpMessageSignatureMiddleware } from "../http_message_signature_middleware";
 import {
   aValidPayload,
-  validLollipopHeaders,
-  validMultisignatureHeaders
+  generateES256Key,
+  generateRSAKey,
+  signEcdsaSha256WithEncoding,
+  signRsaPssSha256WithEncoding,
+  validLollipopExtraHeaders,
+  withIoSignLollipopSignature,
+  withLollipopSignature
 } from "../../../__mocks__/lollipopSignature.mock";
-import {
-  aFiscalCode,
-  aValidSha512AssertionRef
-} from "../../../__mocks__/lollipopPubKey.mock";
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import { AssertionTypeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/lollipop/AssertionType";
+import { aValidSha512AssertionRef } from "../../../__mocks__/lollipopPubKey.mock";
+import { AlgorithmTypes } from "@mattrglobal/http-signatures";
+
+const baseReq = ({
+  app: {
+    get: () => ({
+      bindings: {
+        req: { rawBody: JSON.stringify(aValidPayload) }
+      }
+    })
+  },
+  url:
+    "https://io-p-weu-lollipop-fn.azurewebsites.net/api/v1/first-lollipop-consumer",
+  method: "POST",
+  body: aValidPayload
+} as unknown) as express.Request;
 
 describe("HttpMessageSignatureMiddleware - Success", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   test(`GIVEN a request with a signature
   WHEN the signature is valid, encoding is 'ieee-p1363' and alg is 'ecdsa-p256-sha256'
   THEN the middleware return true`, async () => {
+    const data = await generateES256Key();
+
     const mockReq = ({
-      app: {
-        get: () => ({
-          bindings: {
-            req: { rawBody: JSON.stringify(aValidPayload) }
-          }
-        })
-      },
-      headers: validLollipopHeaders,
-      url:
-        "https://io-p-weu-lollipop-fn.azurewebsites.net/api/v1/first-lollipop-consumer",
-      method: "POST",
-      body: aValidPayload
+      ...baseReq,
+      headers: {
+        ...validLollipopExtraHeaders,
+        ["x-pagopa-lollipop-assertion-ref"]: data.assertionRefSha256,
+        ["x-pagopa-lollipop-public-key"]: data.encodedPubKey
+      }
     } as unknown) as express.Request;
 
-    const res = await HttpMessageSignatureMiddleware()(mockReq);
+    const alg = AlgorithmTypes["ecdsa-p256-sha256"];
+    const mockReqWithSignedParams = await withLollipopSignature(
+      data.thumbprintSha256,
+      "a nonce",
+      alg,
+      data.privateKeyJwk,
+      signEcdsaSha256WithEncoding("ieee-p1363")
+    )(mockReq);
+
+    const res = await HttpMessageSignatureMiddleware()(mockReqWithSignedParams);
 
     expect(res).toMatchObject(E.right(true));
   });
@@ -42,55 +66,63 @@ describe("HttpMessageSignatureMiddleware - Success", () => {
   test(`GIVEN a request with a signature
   WHEN the signature is valid, encoding is 'ieee-p1363' and alg is 'rsa-pss-sha256'
   THEN the middleware return true`, async () => {
+    const data = await generateRSAKey();
+
     const mockReq = ({
-      app: {
-        get: () => ({
-          bindings: {
-            req: { rawBody: JSON.stringify(aValidPayload) }
-          }
-        })
-      },
+      ...baseReq,
       headers: {
-        ...validLollipopHeaders,
-        ["x-pagopa-lollipop-assertion-ref"]:
-          "sha256-A3OhKGLYwSvdJ2txHi_SGQ3G-sHLh2Ibu91ErqFx_58",
-        ["x-pagopa-lollipop-public-key"]:
-          "eyJrZXlfb3BzIjpbInZlcmlmeSJdLCJleHQiOnRydWUsImt0eSI6IlJTQSIsIm4iOiJ2dHAwT3p5aGhsSUh2YjFmR0pKVERJSUtVVmtKcTJrOEJuekNJVThhbFdXWnd6bExVUERUUU55OW1CdUFVWndLZUdEam8xSlBuUjJXQzhWLTlOSVkxZzVUYlg5SGJnZk9rd3YzTVl1V0xhZUVBZmdfT0FFTEJjNjhxV0JZdTdxWXpjSlpPZ3dTdWZRNmxidUlFNXhrcnMtY3Fpc08zMGpFQmF0QjNReXJQZEdid0pXOEJ4bTBqQTZlN1NWcDd3NzUtYkdGeElhMkNDOTNuSWl4ZTNMRnNhRU5yX0lnYlNNM2NDcG00VEFYZHVGc1dHWjU2SkdHYkZBak5hV2s3VDJwMU9qd2owX0RVNzZIRUpEWGdNSkp4b3NtaE9GajdUZE95aE0zTVpWSUFUcEswYkZBdFZpcWk1WGxaTUpXY2FscmJpSkNHTjdBdzV2anBTdkpsOTVkVVRuR1ZTQlZXQ1gyVm9hb2FEVV9sTVNUYkw5Sm5HVlZzX3Ywb3dOR0lELVpHNXQ5Yk9ZYWt4MWJjWWN6ZzcyQVd1V3RHTXFtWDFSSDEwTGlEam10NDh0Yml3Q254ZGVRaGFYa19wNVk0bzFpcnpQWG5nUzVJWWlqZXVXdjlzM2hCY3hGQTRPYURGdjRURkoxVExiRGluUmpfa1hCdjEyWDNLRE9iYWNFdDVLcGVsNUluNlZxZHBNNWVFZnZ0WDU4U0Z2bDktTmphb29PZjZUeUJsOEtVdTZOTmc2OXNYQVFRVnBzdXhpaDl3NzA5RVRObWx1M2tZc21iTWt3MVRGM3hnRmxJSDh2SnI2WWJ6ajFxcDJ1djJaYkFtYXBNLUd1NVRTYUNOSzZKbVpvLV95UVA5dDFGOWZldmUxYzFHZWlvdEtXLUpDalRmYnNodkZ0M1V3eUdyOCIsImUiOiJBUUFCIiwiYWxnIjoiUFM1MTIifQ",
-        Signature:
-          "sig1=:LaN4n+miIZDzPHSV1CwFM/M+qzp0InLYlfxKfOC8b+VMv4q9leZSQcGwLC7uLpvdn4o8q9+LKc6zPbsD6NWtJclbwVLBXJKmpI7OzPkHJhho809JPHiFeQ49o/YfLXGKSlGp0kYmpP6KwsFivkuH54+/I5s5PDJacpQ5J2/j6MeFZH2arft9Kg5ZSOBZdG4EpvAxOrmje8bzIbaptb2DSxdX9YfNiYf6fuMjDnGOVAa3nz8z135tyvPj5tP8P2MKRDKVc2L1sUfpTIJ9HSjcEx6cxhBXdPwozdtVy/we7QXBl+c9fHzCytk3aNlaPh1B10MCwuKQiky8M1GCR1BMC5pIkhXenOcvj7hNkTe1FEwkvLWHCYdJzNLD8ERbTfsKEM1CZt7I5fMBr0/mitOJZ2GBIOnhZZya0oFnR5br22zvXoJL8lS1ajp3Wt3EXSdliDloy5LDOPqxAEH5nXInfxDaYQgZuLWa0I2oLmSr/DlW/KqX0KVCtoJXdwxJjhBS/ZRTdC0u2WmcE0QA0YXeJfUWaU8KS1Nx+Lbz22xEu7kNGTh7r8cmtVzl5bybtpvMUZ7dqNgoW5mcaCUDjeQOinRsugVWVTowTPjJWXW+8cV9LeBJRq4oc9HzoLQDfn/HGoMFpi79pZQIzNFBE3Jpdoouu392AqmEebzEgm2838A=:",
-        ["Signature-Input"]:
-          'sig1=("content-digest" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1678814391;nonce="aNonce";alg="rsa-pss-sha256";keyid="A3OhKGLYwSvdJ2txHi_SGQ3G-sHLh2Ibu91ErqFx_58"'
-      },
-      url:
-        "https://io-p-weu-lollipop-fn.azurewebsites.net/api/v1/first-lollipop-consumer",
-      method: "POST",
-      body: aValidPayload
+        ...validLollipopExtraHeaders,
+        ["x-pagopa-lollipop-assertion-ref"]: data.assertionRefSha256,
+        ["x-pagopa-lollipop-public-key"]: data.encodedPubKey
+      }
     } as unknown) as express.Request;
 
-    const res = await HttpMessageSignatureMiddleware()(mockReq);
+    const alg = "rsa-pss-sha256";
+    const mockReqWithSignedParams = await withLollipopSignature(
+      data.thumbprintSha256,
+      "a nonce",
+      alg,
+      data.privateKeyJwk,
+      signRsaPssSha256WithEncoding("ieee-p1363")
+    )(mockReq);
 
+    const res = await HttpMessageSignatureMiddleware()(mockReqWithSignedParams);
     expect(res).toMatchObject(E.right(true));
   });
 
   test(`GIVEN a request with a multi-signature
   WHEN all the signatures are valid, encoding is 'ieee-p1363' and alg is 'ecdsa-p256-sha256'
   THEN the middleware return true`, async () => {
+    const data = await generateES256Key();
+
     const mockReq = ({
-      app: {
-        get: () => ({
-          bindings: {
-            req: { rawBody: JSON.stringify(aValidPayload) }
-          }
-        })
-      },
-      headers: validMultisignatureHeaders,
-      url:
-        "https://io-p-weu-lollipop-fn.azurewebsites.net/api/v1/first-lollipop-consumer",
-      method: "POST",
-      body: aValidPayload
+      ...baseReq,
+      headers: {
+        ...validLollipopExtraHeaders,
+        ["x-pagopa-lollipop-assertion-ref"]: data.assertionRefSha256,
+        ["x-pagopa-lollipop-public-key"]: data.encodedPubKey,
+        "X-io-sign-qtspclauses": "a value"
+      }
     } as unknown) as express.Request;
 
-    const res = await HttpMessageSignatureMiddleware()(mockReq);
+    const alg = AlgorithmTypes["ecdsa-p256-sha256"];
+
+    const mockReqWith2ndSignedParams = await withIoSignLollipopSignature(
+      data.thumbprintSha256,
+      "a nonce",
+      alg,
+      data.privateKeyJwk,
+      signEcdsaSha256WithEncoding("ieee-p1363")
+    )(mockReq);
+    const mockReqWithSignedParams = await withLollipopSignature(
+      data.thumbprintSha256,
+      "a nonce",
+      alg,
+      data.privateKeyJwk,
+      signEcdsaSha256WithEncoding("ieee-p1363")
+    )(mockReqWith2ndSignedParams);
+
+    const res = await HttpMessageSignatureMiddleware()(mockReqWithSignedParams);
 
     expect(res).toMatchObject(E.right(true));
   });
@@ -98,36 +130,28 @@ describe("HttpMessageSignatureMiddleware - Success", () => {
   test(`GIVEN a request with a signature
   WHEN the signature is valid, encoding is 'der' and alg is 'ecdsa-p256-sha256'
   THEN the middleware return true`, async () => {
+    const data = await generateES256Key();
+
     const mockReq = ({
-      app: {
-        get: () => ({
-          bindings: {
-            req: { rawBody: JSON.stringify(aValidPayload) }
-          }
-        })
-      },
+      ...baseReq,
       headers: {
-        ["x-pagopa-lollipop-assertion-ref"]:
-          "sha256-HiNolL87UYKQfaKISwIzyWY4swKPUzpaOWJCxaHy89M",
-        ["x-pagopa-lollipop-assertion-type"]: AssertionTypeEnum.SAML,
-        ["x-pagopa-lollipop-user-id"]: aFiscalCode,
-        ["x-pagopa-lollipop-public-key"]:
-          "eyJrdHkiOiJFQyIsInkiOiJNdkVCMENsUHFnTlhrNVhIYm9xN1hZUnE2TnJTQkFTVmZhT2wzWnAxQmJzPSIsImNydiI6IlAtMjU2IiwieCI6InF6YTQzdGtLTnIrYWlTZFdNL0Q1cTdxMElmV3lZVUFIVEhSNng3dFByZEU9In0",
-        ["x-pagopa-lollipop-auth-jwt"]: "aValidJWT" as NonEmptyString,
-        "x-pagopa-lollipop-original-method": "POST",
-        "x-pagopa-lollipop-original-url":
-          "https://api-app.io.pagopa.it/first-lollipop/sign",
-        "content-digest":
-          "sha-256=:cpyRqJ1VhoVC+MSs9fq4/4wXs4c46EyEFriskys43Zw=:",
-        "signature-input": `sig1=("x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=1681473980;nonce="aNonce";alg="ecdsa-p256-sha256";keyid="HiNolL87UYKQfaKISwIzyWY4swKPUzpaOWJCxaHy89M"`,
-        signature: `sig1=:MEUCIFiZHxuLhk2Jlt46E5kbB8hCx7fN7QeeAj2gaSK3Y+WzAiEAtggj3Jwu8RbTGdNmsDix2zymh0gKwKxoPlolL7j6VTg=:`
-      },
-      url: "https://api-app.io.pagopa.it/first-lollipop/sign",
-      method: "POST",
-      body: aValidPayload
+        ...validLollipopExtraHeaders,
+        ["x-pagopa-lollipop-assertion-ref"]: data.assertionRefSha256,
+        ["x-pagopa-lollipop-public-key"]: data.encodedPubKey
+      }
     } as unknown) as express.Request;
 
-    const res = await HttpMessageSignatureMiddleware()(mockReq);
+    const alg = AlgorithmTypes["ecdsa-p256-sha256"];
+    const mockReqWithSignedParams = await withLollipopSignature(
+      data.thumbprintSha256,
+      "a nonce",
+      alg,
+      data.privateKeyJwk,
+      signEcdsaSha256WithEncoding("der")
+    )(mockReq);
+
+    const res = await HttpMessageSignatureMiddleware()(mockReqWithSignedParams);
+
     expect(res).toMatchObject(E.right(true));
   });
 });
@@ -136,25 +160,25 @@ describe("HttpMessageSignatureMiddleware - Failures", () => {
   test(`GIVEN a request with a signature
   WHEN the keyid is different from the assertion ref
   THEN the middleware return false`, async () => {
+    const data = await generateES256Key();
+
     const mockReq = ({
-      app: {
-        get: () => ({
-          bindings: {
-            req: { rawBody: JSON.stringify(aValidPayload) }
-          }
-        })
-      },
+      ...baseReq,
       headers: {
-        ...validLollipopHeaders,
+        ...validLollipopExtraHeaders,
         ["x-pagopa-lollipop-assertion-ref"]: aValidSha512AssertionRef
-      },
-      url:
-        "https://io-p-weu-lollipop-fn.azurewebsites.net/api/v1/first-lollipop-consumer",
-      method: "POST",
-      body: aValidPayload
+      }
     } as unknown) as express.Request;
 
-    const res = await HttpMessageSignatureMiddleware()(mockReq);
+    const alg = AlgorithmTypes["ecdsa-p256-sha256"];
+    const mockReqWithSignedParams = await withLollipopSignature(
+      data.thumbprintSha256,
+      "a nonce",
+      alg,
+      data.privateKeyJwk,
+      signEcdsaSha256WithEncoding("ieee-p1363")
+    )(mockReq);
+    const res = await HttpMessageSignatureMiddleware()(mockReqWithSignedParams);
 
     expect(res).toMatchObject(
       E.left(

--- a/utils/middleware/__tests__/http_message_signature_middleware.test.ts
+++ b/utils/middleware/__tests__/http_message_signature_middleware.test.ts
@@ -1,20 +1,21 @@
 import * as express from "express";
 
 import * as E from "fp-ts/Either";
+import { AlgorithmTypes } from "@mattrglobal/http-signatures";
 
 import { HttpMessageSignatureMiddleware } from "../http_message_signature_middleware";
 import {
   aValidPayload,
   generateES256Key,
   generateRSAKey,
+  getValidLollipopLCParamsHeaders,
   signEcdsaSha256WithEncoding,
   signRsaPssSha256WithEncoding,
-  validLollipopExtraHeaders,
+  validLollipopLCParamsHeaders,
   withIoSignLollipopSignature,
   withLollipopSignature
 } from "../../../__mocks__/lollipopSignature.mock";
 import { aValidSha512AssertionRef } from "../../../__mocks__/lollipopPubKey.mock";
-import { AlgorithmTypes } from "@mattrglobal/http-signatures";
 
 const baseReq = ({
   app: {
@@ -42,18 +43,16 @@ describe("HttpMessageSignatureMiddleware - Success", () => {
 
     const mockReq = ({
       ...baseReq,
-      headers: {
-        ...validLollipopExtraHeaders,
-        ["x-pagopa-lollipop-assertion-ref"]: data.assertionRefSha256,
-        ["x-pagopa-lollipop-public-key"]: data.encodedPubKey
-      }
+      headers: getValidLollipopLCParamsHeaders(
+        data.assertionRefSha256,
+        data.encodedPubKey
+      )
     } as unknown) as express.Request;
 
-    const alg = AlgorithmTypes["ecdsa-p256-sha256"];
     const mockReqWithSignedParams = await withLollipopSignature(
       data.thumbprintSha256,
       "a nonce",
-      alg,
+      AlgorithmTypes["ecdsa-p256-sha256"],
       data.privateKeyJwk,
       signEcdsaSha256WithEncoding("ieee-p1363")
     )(mockReq);
@@ -70,18 +69,16 @@ describe("HttpMessageSignatureMiddleware - Success", () => {
 
     const mockReq = ({
       ...baseReq,
-      headers: {
-        ...validLollipopExtraHeaders,
-        ["x-pagopa-lollipop-assertion-ref"]: data.assertionRefSha256,
-        ["x-pagopa-lollipop-public-key"]: data.encodedPubKey
-      }
+      headers: getValidLollipopLCParamsHeaders(
+        data.assertionRefSha256,
+        data.encodedPubKey
+      )
     } as unknown) as express.Request;
 
-    const alg = "rsa-pss-sha256";
     const mockReqWithSignedParams = await withLollipopSignature(
       data.thumbprintSha256,
       "a nonce",
-      alg,
+      "rsa-pss-sha256",
       data.privateKeyJwk,
       signRsaPssSha256WithEncoding("ieee-p1363")
     )(mockReq);
@@ -98,15 +95,15 @@ describe("HttpMessageSignatureMiddleware - Success", () => {
     const mockReq = ({
       ...baseReq,
       headers: {
-        ...validLollipopExtraHeaders,
-        ["x-pagopa-lollipop-assertion-ref"]: data.assertionRefSha256,
-        ["x-pagopa-lollipop-public-key"]: data.encodedPubKey,
+        ...getValidLollipopLCParamsHeaders(
+          data.assertionRefSha256,
+          data.encodedPubKey
+        ),
         "X-io-sign-qtspclauses": "a value"
       }
     } as unknown) as express.Request;
 
     const alg = AlgorithmTypes["ecdsa-p256-sha256"];
-
     const mockReqWith2ndSignedParams = await withIoSignLollipopSignature(
       data.thumbprintSha256,
       "a nonce",
@@ -116,7 +113,7 @@ describe("HttpMessageSignatureMiddleware - Success", () => {
     )(mockReq);
     const mockReqWithSignedParams = await withLollipopSignature(
       data.thumbprintSha256,
-      "a nonce",
+      "another nonce",
       alg,
       data.privateKeyJwk,
       signEcdsaSha256WithEncoding("ieee-p1363")
@@ -134,18 +131,16 @@ describe("HttpMessageSignatureMiddleware - Success", () => {
 
     const mockReq = ({
       ...baseReq,
-      headers: {
-        ...validLollipopExtraHeaders,
-        ["x-pagopa-lollipop-assertion-ref"]: data.assertionRefSha256,
-        ["x-pagopa-lollipop-public-key"]: data.encodedPubKey
-      }
+      headers: getValidLollipopLCParamsHeaders(
+        data.assertionRefSha256,
+        data.encodedPubKey
+      )
     } as unknown) as express.Request;
 
-    const alg = AlgorithmTypes["ecdsa-p256-sha256"];
     const mockReqWithSignedParams = await withLollipopSignature(
       data.thumbprintSha256,
       "a nonce",
-      alg,
+      AlgorithmTypes["ecdsa-p256-sha256"],
       data.privateKeyJwk,
       signEcdsaSha256WithEncoding("der")
     )(mockReq);
@@ -165,16 +160,15 @@ describe("HttpMessageSignatureMiddleware - Failures", () => {
     const mockReq = ({
       ...baseReq,
       headers: {
-        ...validLollipopExtraHeaders,
+        ...validLollipopLCParamsHeaders,
         ["x-pagopa-lollipop-assertion-ref"]: aValidSha512AssertionRef
       }
     } as unknown) as express.Request;
 
-    const alg = AlgorithmTypes["ecdsa-p256-sha256"];
     const mockReqWithSignedParams = await withLollipopSignature(
       data.thumbprintSha256,
       "a nonce",
-      alg,
+      AlgorithmTypes["ecdsa-p256-sha256"],
       data.privateKeyJwk,
       signEcdsaSha256WithEncoding("ieee-p1363")
     )(mockReq);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

- Fix signature validation
- Mock http signature in tests

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

keyId is now handled as thumbprint

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
