### PR TITLE
[#IOPID-1643] Fix ReDOS vulnerability on Lollipop SignatureInput param

### DIFF
--- a/openapi/lollipop_first_consumer.yaml
+++ b/openapi/lollipop_first_consumer.yaml
@@ -178,7 +178,7 @@ components:
 
     LollipopSignatureInput:
       type: string
-      pattern: "^(((sig[0-9]+)=[^,]*?)(, ?)?)+$"
+      pattern: "^(?:sig\\d+=[^,]*)(?:,\\s*(?:sig\\d+=[^,]*))*$"
     LollipopSignature:
       type: string
       pattern: "^((sig[0-9]+)=:[A-Za-z0-9+/=]*:(, ?)?)+$"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Change the regex for `SignatureInput` lollipop parameter in openapi specs and generated type

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current regex has a DOS vulnerability

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
not tested

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
